### PR TITLE
Change Exporter version requirements to match upstream version decima…

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,7 +27,7 @@ WriteMakefile1(
                       'Test::More'       => '0.45',
                     },
     PREREQ_PM    => {
-                      'Exporter'         => '5.562',
+                      'Exporter'         => '5.57',
                       'XSLoader'         => '0.01',
                       'Carp'             => 0,
                       'base'             => 0,


### PR DESCRIPTION
…l length

Some packaging system's version logic get a little confused when the version
decimal length is off. This change bumps the Exporter requirement a little but
still keeps compatibility with the version of Exporter as of 2008.