### PR TITLE
Add typedef for int32_t when using MSVC

### DIFF
--- a/ptypes.h
+++ b/ptypes.h
@@ -5,6 +5,7 @@
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #else
+  typedef __int32 int32_t;
   typedef unsigned __int32 uint32_t;
   typedef unsigned __int64 uint64_t;
 #endif


### PR DESCRIPTION
int32_t is used in one place in factor.c and needs to be defined here for MSVC. 