### PR TITLE
Reduce Ql mod n in alt_lucas_seq()

### DIFF
--- a/primality.c
+++ b/primality.c
@@ -413,6 +413,7 @@ void alt_lucas_seq(mpz_t Uh, mpz_t Vl, mpz_t n, IV P, IV Q, mpz_t k,
       mpz_mul_si(t, Ql, P);  mpz_mul(Vh, Vh, Vl); mpz_sub(Vh, Vh, t);
       mpz_mul(Vl, Vl, Vl);  mpz_sub(Vl, Vl, Ql);  mpz_sub(Vl, Vl, Ql);
     }
+    mpz_mod(Ql, Ql, n);
     mpz_mod(Qh, Qh, n);
     mpz_mod(Uh, Uh, n);
     mpz_mod(Vh, Vh, n);


### PR DESCRIPTION
This fixes a performance issue in the `lucas_sequence(n, p, q, k)` function for large `k` and even `n`.

For example:

```perl
use Math::Prime::Util::GMP qw(:all);
CORE::say join(' ', lucas_sequence("1234512312312312892374278", 1, -1, factorial(2000)));
```

Before it took 3.7s. Now it takes only 0.028s.