### PR TITLE
Include misc_ui.h in pbrent63.c

### DIFF
--- a/pbrent63.c
+++ b/pbrent63.c
@@ -8,6 +8,7 @@
 
 #define FUNC_gcd_ui 1
 #include "utility.h"
+#include "misc_ui.h"
 
 static INLINE UV mpz_getuv(mpz_t n) {
   UV v = mpz_getlimbn(n,0);


### PR DESCRIPTION
Otherwise, it fails to compile with GCC on 64-bit systems, producing the following error:

```
pbrent63.c: In function ‘uvpbrent63’:
pbrent63.c:126:11: error: implicit declaration of function ‘gcd_ui’ [-Wimplicit-function-declaration]
  126 |       f = gcd_ui(m, n);
      |           ^~~~~~
make: *** [Makefile:408: pbrent63.o] Error 1
make: *** Waiting for unfinished jobs....
FAIL
```