### PR TITLE
Update test for $fname(1) to expect an empty array

### DIFF
--- a/t/50-factoring.t
+++ b/t/50-factoring.t
@@ -190,7 +190,7 @@ sub extra_factor_test {
   my $fsub = shift;
 
   is_deeply( [ sort {$a<=>$b} $fsub->(0)   ], [0],       "$fname(0)" );
-  is_deeply( [ sort {$a<=>$b} $fsub->(1)   ], [1],       "$fname(1)" );
+  is_deeply( [ sort {$a<=>$b} $fsub->(1)   ], [],        "$fname(1)" );
   is_deeply( [ sort {$a<=>$b} $fsub->(2)   ], [2],       "$fname(2)" );
   is_deeply( [ sort {$a<=>$b} $fsub->(13)  ], [13],      "$fname(13)" );
   is_deeply( [ sort {$a<=>$b} $fsub->(403) ], [13, 31],  "$fname(403)" );


### PR DESCRIPTION
Fixes tests for `*_factor(1)`, which now return an empty list, introduced in: https://github.com/danaj/Math-Prime-Util-GMP/commit/6f57a9bc5a42f6094dc1a873b930a7e2691e5921